### PR TITLE
Add support for auto-traversals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for auto-traversals to search for `Ref`s
+
+### Removed
+
+- Removed `defineTraversal`, as it is obviated by auto-traversals
+
 ## [0.5.0] - 2022-03-09
 
 ### Added

--- a/src/__tests__/public-api.test.ts
+++ b/src/__tests__/public-api.test.ts
@@ -26,6 +26,28 @@ describe('Public API', () => {
     });
   });
 
+  it('works with an entity containing an array field', () => {
+    const Post = t.strict({
+      title: t.string,
+      tags: t.array(t.string),
+    });
+
+    define(Post, {
+      manifest: ({ faker }) =>
+        Post.encode({
+          title: faker.random.words(),
+          tags: [faker.random.word(), faker.random.word(), faker.random.word()],
+        }),
+    });
+
+    const post = manifest(Post);
+
+    expect(post).toEqual({
+      title: expect.any(String),
+      tags: [expect.any(String), expect.any(String), expect.any(String)],
+    });
+  });
+
   it('works with an entity hierarchy', () => {
     const Author = t.type({
       id: t.string,

--- a/src/global-realm.ts
+++ b/src/global-realm.ts
@@ -2,6 +2,6 @@ import { Realm } from './realm';
 
 const globalRealm = new Realm();
 
-const { define, defineTraversal, manifest, persist } = globalRealm;
+const { define, manifest, persist } = globalRealm;
 
-export { define, defineTraversal, manifest, persist };
+export { define, manifest, persist };

--- a/src/realm.ts
+++ b/src/realm.ts
@@ -2,12 +2,10 @@ import { faker } from '@faker-js/faker';
 import * as t from 'io-ts';
 import { RealmStorage } from './realm-storage';
 import { isMappedRef, ManifestedRef, MappedRef } from './ref';
-import { Define, DefineTraversal, EntityC, Manifest, Persist } from './types';
+import { Define, EntityC, Manifest, Persist } from './types';
 
 export class Realm {
   private readonly storage = new RealmStorage();
-
-  readonly defineTraversal: DefineTraversal = _traversal => {};
 
   readonly define: Define = (
     Entity,

--- a/src/realm.ts
+++ b/src/realm.ts
@@ -2,27 +2,12 @@ import { faker } from '@faker-js/faker';
 import * as t from 'io-ts';
 import { RealmStorage } from './realm-storage';
 import { isMappedRef, ManifestedRef, MappedRef } from './ref';
-import {
-  Define,
-  DefineTraversal,
-  EntityC,
-  Manifest,
-  Persist,
-  Traversal,
-} from './types';
-
-const identityTraversal: Traversal<unknown> = {
-  is: (_value: unknown): _value is unknown => true,
-  traverse: f => x => f(x),
-};
+import { Define, DefineTraversal, EntityC, Manifest, Persist } from './types';
 
 export class Realm {
   private readonly storage = new RealmStorage();
-  private readonly traversals: Traversal<any>[] = [identityTraversal];
 
-  readonly defineTraversal: DefineTraversal = traversal => {
-    this.traversals.push(traversal);
-  };
+  readonly defineTraversal: DefineTraversal = _traversal => {};
 
   readonly define: Define = (
     Entity,
@@ -88,10 +73,20 @@ export class Realm {
         continue;
       }
 
-      for (const traversal of this.traversals) {
-        if (traversal.is(value)) {
-          manifestedEntity[key] = traversal.traverse(maybeProcessRef)(value);
+      if (isMappedRef(value)) {
+        manifestedEntity[key] = processRef(value);
+        continue;
+      }
+
+      if (t.UnknownRecord.is(value)) {
+        const acc: Record<string, unknown> = {};
+
+        for (const [subKey, subValue] of Object.entries(value)) {
+          acc[subKey] = maybeProcessRef(subValue);
         }
+
+        manifestedEntity[key] = acc;
+        continue;
       }
     }
 

--- a/src/ref.test.ts
+++ b/src/ref.test.ts
@@ -4,17 +4,12 @@ import * as t from 'io-ts';
 import { either, option } from 'io-ts-types';
 import { Realm } from './realm';
 import { Ref } from './ref';
-import { ManifesterOptions, Traversal } from './types';
+import { ManifesterOptions } from './types';
 
 describe('Ref', () => {
   describe('when used inside of an `Option`', () => {
     it(`calls the referenced entity's manifester`, () => {
       const realm = new Realm();
-
-      realm.defineTraversal({
-        is: option(t.unknown).is,
-        traverse: O.map,
-      });
 
       const Author = t.strict({ id: t.string });
 
@@ -49,16 +44,9 @@ describe('Ref', () => {
   });
 
   describe('when used inside of an `Either`', () => {
-    const eitherTraversal: Traversal<E.Either<unknown, unknown>> = {
-      is: either(t.unknown, t.unknown).is,
-      traverse: f => E.bimap(f, f),
-    };
-
     describe('inside of a `Left`', () => {
       it(`calls the referenced entity's manifester`, () => {
         const realm = new Realm();
-
-        realm.defineTraversal(eitherTraversal);
 
         const Author = t.strict({ id: t.string });
 
@@ -95,8 +83,6 @@ describe('Ref', () => {
     describe('inside of a `Right`', () => {
       it(`calls the referenced entity's manifester`, () => {
         const realm = new Realm();
-
-        realm.defineTraversal(eitherTraversal);
 
         const Author = t.strict({ id: t.string });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,11 +13,6 @@ export type Manifester<T> = (options: ManifesterOptions) => T;
 
 export type Persister<T> = (entity: T) => Promise<T>;
 
-export interface Traversal<T> {
-  is: (value: unknown) => value is T;
-  traverse: (f: (value: unknown) => unknown) => (container: T) => T;
-}
-
 export interface DefineOptions<T> {
   manifest: Manifester<T>;
   persist?: Persister<T>;
@@ -27,8 +22,6 @@ export type Define = <C extends EntityC>(
   Entity: C,
   options: DefineOptions<t.OutputOf<C>>
 ) => void;
-
-export type DefineTraversal = <T>(traversal: Traversal<T>) => void;
 
 export type Manifest = <C extends EntityC>(
   Entity: C,


### PR DESCRIPTION
This PR adds support for auto-traversals.

Auto-traversals supersede the manual traversals API that was added in #1.

Previously the library consumer would have to define traversals over each data type in order to find `Ref`s within them. With auto-traversals, Thaumaturge will now walk the entity's object graph in search for any `Ref`s.

Resolves #3.