### PR TITLE
Remove Faker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `uuid` to `ManifesterOptions`
+- Added `sequences` to `ManifesterOptions`
+
+### Removed
+
+- Removed `faker` from `ManifesterOptions`
+
 ## [0.8.0] - 2022-06-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ const Movie = t.strict({
 });
 
 define(Movie, {
-  manifest: ({ sequences }) => ({
-    title: sequences.titles.next(),
-    year: sequences.years.next(),
-  }),
   sequences: {
     titles: new Sequence(n => `Movie ${n}` as const),
     years: new Sequence(n => 2022 - n),
   },
+  manifest: ({ sequences }) => ({
+    title: sequences.titles.next(),
+    year: sequences.years.next(),
+  }),
 });
 
 const movie = manifest(Movie);

--- a/README.md
+++ b/README.md
@@ -35,16 +35,20 @@ const Movie = t.strict({
 });
 
 define(Movie, {
-  manifest: ({ faker }) => ({
-    title: faker.random.words(),
-    year: faker.date.past(10).getFullYear(),
+  manifest: ({ sequences }) => ({
+    title: sequences.titles.next(),
+    year: sequences.years.next(),
   }),
+  sequences: {
+    titles: new Sequence(n => `Movie ${n}` as const),
+    years: new Sequence(n => 2022 - n),
+  },
 });
 
 const movie = manifest(Movie);
 
 console.log(movie);
-// > { title: 'efficient turn-key', year: 2021 }
+// > { title: 'Movie 1', year: 2021 }
 ```
 
 ### Entity Hierarchies
@@ -65,17 +69,17 @@ const Book = t.type({
 });
 
 define(Author, {
-  manifest: ({ faker }) => ({
-    id: faker.datatype.uuid(),
-    name: faker.name.findName(),
+  manifest: ({ uuid }) => ({
+    id: uuid(),
+    name: 'J. R. R. Tolkien',
   }),
 });
 
 define(Book, {
-  manifest: ({ faker }) => ({
-    id: faker.datatype.uuid(),
+  manifest: ({ uuid }) => ({
+    id: uuid(),
     authorId: Ref.to(Author).through(author => author.id),
-    title: faker.random.words(),
+    title: 'The Lord of the Rings',
   }),
 });
 
@@ -85,6 +89,6 @@ console.log(book);
 // > {
 //     id: '1ab4790a-9911-4e20-9006-b12e6b60dfe6',
 //     authorId: 'c6a1f6e0-6845-4675-b570-87024446a371',
-//     title: 'Tuna Central'
+//     title: 'The Lord of the Rings'
 //   }
 ```

--- a/package.json
+++ b/package.json
@@ -34,10 +34,11 @@
     "io-ts": "2.x"
   },
   "dependencies": {
-    "@faker-js/faker": "7.3.0"
+    "uuid": "8.3.2"
   },
   "devDependencies": {
     "@types/jest": "28.1.6",
+    "@types/uuid": "8.3.4",
     "fp-ts": "2.12.2",
     "io-ts": "2.2.17",
     "io-ts-types": "0.5.16",

--- a/src/__tests__/public-api.test.ts
+++ b/src/__tests__/public-api.test.ts
@@ -12,8 +12,8 @@ describe('Public API', () => {
 
     define(Movie, {
       sequences: {
-        movies: new Sequence(n => `Movie ${n}` as const),
-        years: new Sequence(n => 2022 - n),
+        movies: n => `Movie ${n}` as const,
+        years: n => 2022 - n,
       },
       manifest: ({ sequences }) => ({
         title: sequences.movies.next(),

--- a/src/__tests__/public-api.test.ts
+++ b/src/__tests__/public-api.test.ts
@@ -1,7 +1,7 @@
 import * as t from 'io-ts';
 // Importing from the root barrel file intentionally to simulate what library
 // consumers will see.
-import { define, manifest, Ref } from '..';
+import { define, manifest, Ref, Sequence } from '..';
 
 describe('Public API', () => {
   it('works with a basic example', () => {
@@ -11,9 +11,13 @@ describe('Public API', () => {
     });
 
     define(Movie, {
-      manifest: ({ uuid }) => ({
-        title: uuid(),
-        year: 2020,
+      sequences: {
+        movies: new Sequence(n => `Movie ${n}`),
+        years: new Sequence(n => 2022 - n),
+      },
+      manifest: ({ sequences }) => ({
+        title: sequences.movies.next(),
+        year: sequences.years.next(),
       }),
     });
 
@@ -32,13 +36,18 @@ describe('Public API', () => {
     });
 
     define(Post, {
-      manifest: ({ uuid }) => ({
+      manifest: ({ uuid, sequences }) => ({
         title: uuid(),
-        tags: [uuid(), uuid(), uuid()],
+        tags: sequences.tags.take(3),
       }),
+      sequences: {
+        tags: new Sequence(n => `Tag ${n}`),
+      },
     });
 
     const post = manifest(Post);
+
+    console.log(post);
 
     expect(post).toEqual({
       title: expect.any(String),

--- a/src/__tests__/public-api.test.ts
+++ b/src/__tests__/public-api.test.ts
@@ -12,7 +12,7 @@ describe('Public API', () => {
 
     define(Movie, {
       sequences: {
-        movies: new Sequence(n => `Movie ${n}`),
+        movies: new Sequence(n => `Movie ${n}` as const),
         years: new Sequence(n => 2022 - n),
       },
       manifest: ({ sequences }) => ({
@@ -41,7 +41,7 @@ describe('Public API', () => {
         tags: sequences.tags.take(3),
       }),
       sequences: {
-        tags: new Sequence(n => `Tag ${n}`),
+        tags: new Sequence(n => `Tag ${n}` as const),
       },
     });
 

--- a/src/__tests__/public-api.test.ts
+++ b/src/__tests__/public-api.test.ts
@@ -47,8 +47,6 @@ describe('Public API', () => {
 
     const post = manifest(Post);
 
-    console.log(post);
-
     expect(post).toEqual({
       title: expect.any(String),
       tags: [expect.any(String), expect.any(String), expect.any(String)],

--- a/src/__tests__/public-api.test.ts
+++ b/src/__tests__/public-api.test.ts
@@ -11,9 +11,9 @@ describe('Public API', () => {
     });
 
     define(Movie, {
-      manifest: ({ faker }) => ({
-        title: faker.random.words(),
-        year: faker.date.past(10).getFullYear(),
+      manifest: ({ uuid }) => ({
+        title: uuid(),
+        year: 2020,
       }),
     });
 
@@ -32,9 +32,9 @@ describe('Public API', () => {
     });
 
     define(Post, {
-      manifest: ({ faker }) => ({
-        title: faker.random.words(),
-        tags: [faker.random.word(), faker.random.word(), faker.random.word()],
+      manifest: ({ uuid }) => ({
+        title: uuid(),
+        tags: [uuid(), uuid(), uuid()],
       }),
     });
 
@@ -59,17 +59,17 @@ describe('Public API', () => {
     });
 
     define(Author, {
-      manifest: ({ faker }) => ({
-        id: faker.datatype.uuid(),
-        name: faker.name.findName(),
+      manifest: ({ uuid }) => ({
+        id: uuid(),
+        name: uuid(),
       }),
     });
 
     define(Book, {
-      manifest: ({ faker }) => ({
-        id: faker.datatype.uuid(),
+      manifest: ({ uuid }) => ({
+        id: uuid(),
         authorId: Ref.to(Author).through(author => author.id),
-        title: faker.random.words(),
+        title: uuid(),
       }),
     });
 

--- a/src/__tests__/public-api.test.ts
+++ b/src/__tests__/public-api.test.ts
@@ -36,11 +36,12 @@ describe('Public API', () => {
     });
 
     define(Post, {
-      manifest: ({ uuid, sequences }) => ({
-        title: uuid(),
+      manifest: ({ sequences }) => ({
+        title: sequences.titles.next(),
         tags: sequences.tags.take(3),
       }),
       sequences: {
+        titles: new Sequence(n => `Post ${n}` as const),
         tags: new Sequence(n => `Tag ${n}` as const),
       },
     });
@@ -68,7 +69,7 @@ describe('Public API', () => {
     define(Author, {
       manifest: ({ uuid }) => ({
         id: uuid(),
-        name: uuid(),
+        name: 'J. R. R. Tolkien',
       }),
     });
 
@@ -76,7 +77,7 @@ describe('Public API', () => {
       manifest: ({ uuid }) => ({
         id: uuid(),
         authorId: Ref.to(Author).through(author => author.id),
-        title: uuid(),
+        title: 'The Lord of the Rings',
       }),
     });
 

--- a/src/__tests__/public-api.test.ts
+++ b/src/__tests__/public-api.test.ts
@@ -12,8 +12,8 @@ describe('Public API', () => {
 
     define(Movie, {
       sequences: {
-        movies: n => `Movie ${n}` as const,
-        years: n => 2022 - n,
+        movies: new Sequence(n => `Movie ${n}` as const),
+        years: new Sequence(n => 2022 - n),
       },
       manifest: ({ sequences }) => ({
         title: sequences.movies.next(),

--- a/src/__tests__/realm.define.test.ts
+++ b/src/__tests__/realm.define.test.ts
@@ -1,4 +1,3 @@
-import { faker } from '@faker-js/faker';
 import * as t from 'io-ts';
 import { Realm } from '../realm';
 
@@ -27,22 +26,22 @@ describe('Realm', () => {
         expect(manifester).toHaveBeenCalledTimes(1);
       });
 
-      it('passes a Faker instance to the manifester', () => {
-        const realm = new Realm();
+      // it('passes a Faker instance to the manifester', () => {
+      //   const realm = new Realm();
 
-        const manifester = jest.fn<Movie, []>(() => ({
-          title: 'Pulp Fiction',
-          year: 1994 as t.Int,
-        }));
+      //   const manifester = jest.fn<Movie, []>(() => ({
+      //     title: 'Pulp Fiction',
+      //     year: 1994 as t.Int,
+      //   }));
 
-        realm.define(Movie, { manifest: manifester });
+      //   realm.define(Movie, { manifest: manifester });
 
-        realm.manifest(Movie);
+      //   realm.manifest(Movie);
 
-        expect(manifester).toHaveBeenCalledWith(
-          expect.objectContaining({ faker })
-        );
-      });
+      //   expect(manifester).toHaveBeenCalledWith(
+      //     expect.objectContaining({ faker })
+      //   );
+      // });
     });
 
     describe('when `persist` is invoked', () => {

--- a/src/__tests__/realm.define.test.ts
+++ b/src/__tests__/realm.define.test.ts
@@ -26,22 +26,22 @@ describe('Realm', () => {
         expect(manifester).toHaveBeenCalledTimes(1);
       });
 
-      // it('passes a Faker instance to the manifester', () => {
-      //   const realm = new Realm();
+      it('passes a `uuid` function to the manifester', () => {
+        const realm = new Realm();
 
-      //   const manifester = jest.fn<Movie, []>(() => ({
-      //     title: 'Pulp Fiction',
-      //     year: 1994 as t.Int,
-      //   }));
+        const manifester = jest.fn<Movie, []>(() => ({
+          title: 'Pulp Fiction',
+          year: 1994 as t.Int,
+        }));
 
-      //   realm.define(Movie, { manifest: manifester });
+        realm.define(Movie, { manifest: manifester });
 
-      //   realm.manifest(Movie);
+        realm.manifest(Movie);
 
-      //   expect(manifester).toHaveBeenCalledWith(
-      //     expect.objectContaining({ faker })
-      //   );
-      // });
+        expect(manifester).toHaveBeenCalledWith(
+          expect.objectContaining({ uuid: expect.any(Function) })
+        );
+      });
     });
 
     describe('when `persist` is invoked', () => {

--- a/src/__tests__/realm.persist.test.ts
+++ b/src/__tests__/realm.persist.test.ts
@@ -212,9 +212,9 @@ describe('Realm', () => {
         const realm = new Realm();
 
         realm.define(Author, {
-          manifest: ({ faker }) => ({
-            id: faker.datatype.uuid(),
-            name: faker.name.findName(),
+          manifest: ({ uuid }) => ({
+            id: uuid(),
+            name: uuid(),
           }),
           persist: async author => {
             await db.run(
@@ -228,10 +228,10 @@ describe('Realm', () => {
         });
 
         realm.define(Post, {
-          manifest: ({ faker }) => ({
-            id: faker.datatype.uuid(),
+          manifest: ({ uuid }) => ({
+            id: uuid(),
             authorId: Ref.to(Author).through(author => author.id),
-            title: faker.random.words(),
+            title: uuid(),
           }),
           persist: async post => {
             await db.run(
@@ -246,10 +246,10 @@ describe('Realm', () => {
         });
 
         realm.define(Comment, {
-          manifest: ({ faker }) => ({
-            id: faker.datatype.uuid(),
+          manifest: ({ uuid }) => ({
+            id: uuid(),
             postId: Ref.to(Post).through(post => post.id),
-            username: faker.internet.userName(),
+            username: uuid(),
           }),
           persist: async comment => {
             await db.run(

--- a/src/__tests__/realm.persist.test.ts
+++ b/src/__tests__/realm.persist.test.ts
@@ -3,6 +3,7 @@ import { open } from 'sqlite';
 import sqlite3 from 'sqlite3';
 import { Realm } from '../realm';
 import { Ref } from '../ref';
+import { Sequence } from '../sequence';
 
 describe('Realm', () => {
   describe('persist', () => {
@@ -212,9 +213,12 @@ describe('Realm', () => {
         const realm = new Realm();
 
         realm.define(Author, {
-          manifest: ({ uuid }) => ({
+          sequences: {
+            names: new Sequence(n => `Author ${n}` as const),
+          },
+          manifest: ({ uuid, sequences }) => ({
             id: uuid(),
-            name: uuid(),
+            name: sequences.names.next(),
           }),
           persist: async author => {
             await db.run(
@@ -228,10 +232,13 @@ describe('Realm', () => {
         });
 
         realm.define(Post, {
-          manifest: ({ uuid }) => ({
+          sequences: {
+            titles: new Sequence(n => `Post ${n}` as const),
+          },
+          manifest: ({ uuid, sequences }) => ({
             id: uuid(),
             authorId: Ref.to(Author).through(author => author.id),
-            title: uuid(),
+            title: sequences.titles.next(),
           }),
           persist: async post => {
             await db.run(
@@ -246,10 +253,13 @@ describe('Realm', () => {
         });
 
         realm.define(Comment, {
-          manifest: ({ uuid }) => ({
+          sequences: {
+            usernames: new Sequence(n => `user${n}` as const),
+          },
+          manifest: ({ uuid, sequences }) => ({
             id: uuid(),
             postId: Ref.to(Post).through(post => post.id),
-            username: uuid(),
+            username: sequences.usernames.next(),
           }),
           persist: async comment => {
             await db.run(

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,5 @@ export * from './errors';
 export * from './global-realm';
 export * from './realm';
 export * from './ref';
+export * from './sequence';
 export * from './types';

--- a/src/realm-storage.test.ts
+++ b/src/realm-storage.test.ts
@@ -5,6 +5,7 @@ import {
   PersisterNotFoundError,
 } from './errors';
 import { RealmStorage } from './realm-storage';
+import { Sequence } from './sequence';
 
 describe('RealmStorage', () => {
   describe('registerManifester', () => {
@@ -134,6 +135,20 @@ describe('RealmStorage', () => {
       storage.clear();
 
       expect(() => storage.findPersister('User')).toThrow();
+    });
+
+    it('clears the registered sequences', () => {
+      const storage = new RealmStorage();
+
+      storage.registerSequences('User', {
+        firstNames: new Sequence(n => `John ${n}` as const),
+      });
+
+      expect(storage.findSequences('User')).toBeDefined();
+
+      storage.clear();
+
+      expect(storage.findSequences('User')).toBeUndefined();
     });
   });
 });

--- a/src/realm-storage.ts
+++ b/src/realm-storage.ts
@@ -37,7 +37,7 @@ export class RealmStorage {
   }
 
   /**
-   * Returns the manifester registered under the specified entity name
+   * Returns the manifester registered under the specified entity name.
    *
    * Throws a `ManifesterNotFoundError` if there is no manifester registered
    * under the specified entity name.
@@ -57,7 +57,7 @@ export class RealmStorage {
    * Registers a persister under the specified entity name.
    *
    * @param entityName The name of the entity to register the persister under.
-   * @param persister The manifester to register.
+   * @param persister The persister to register.
    */
   registerPersister(entityName: EntityName, persister: Persister<any>) {
     if (this.persisters.has(entityName)) {
@@ -68,7 +68,7 @@ export class RealmStorage {
   }
 
   /**
-   * Returns the persister registered under the specified entity name
+   * Returns the persister registered under the specified entity name.
    *
    * Throws a `PersisterNotFoundError` if there is no persister registered
    * under the specified entity name.
@@ -84,6 +84,12 @@ export class RealmStorage {
     return persister;
   }
 
+  /**
+   * Registers a collection of sequences under the specified entity name.
+   *
+   * @param entityName The name of the entity to register the sequences under.
+   * @param sequences The sequences to register.
+   */
   registerSequences(
     entityName: EntityName,
     sequences: Record<string, Sequence<any>>
@@ -91,6 +97,14 @@ export class RealmStorage {
     this.sequences.set(entityName, sequences);
   }
 
+  /**
+   * Returns the sequences registered under the specified entity name.
+   *
+   * Returns `undefined` if there are no sequences registered under the specified
+   * entity name.
+   *
+   * @param entityName The name of the entity to find the sequences for.
+   */
   findSequences(entityName: EntityName) {
     return this.sequences.get(entityName);
   }
@@ -102,5 +116,6 @@ export class RealmStorage {
   clear() {
     this.manifesters.clear();
     this.persisters.clear();
+    this.sequences.clear();
   }
 }

--- a/src/realm-storage.ts
+++ b/src/realm-storage.ts
@@ -4,6 +4,7 @@ import {
   PersisterAlreadyRegisteredError,
   PersisterNotFoundError,
 } from './errors';
+import { Sequence } from './sequence';
 import { EntityName, Manifester, Persister } from './types';
 
 /**
@@ -14,8 +15,12 @@ import { EntityName, Manifester, Persister } from './types';
  * @internal
  */
 export class RealmStorage {
-  private readonly manifesters = new Map<EntityName, Manifester<any>>();
+  private readonly manifesters = new Map<EntityName, Manifester<any, any>>();
   private readonly persisters = new Map<EntityName, Persister<any>>();
+  private readonly sequences = new Map<
+    EntityName,
+    Record<string, Sequence<any>>
+  >();
 
   /**
    * Registers a manifester under the specified entity name.
@@ -23,7 +28,7 @@ export class RealmStorage {
    * @param entityName The name of the entity to register the manifester under.
    * @param manifester The manifester to register.
    */
-  registerManifester(entityName: EntityName, manifester: Manifester<any>) {
+  registerManifester(entityName: EntityName, manifester: Manifester<any, any>) {
     if (this.manifesters.has(entityName)) {
       throw new ManifesterAlreadyRegisteredError(entityName);
     }
@@ -77,6 +82,17 @@ export class RealmStorage {
     }
 
     return persister;
+  }
+
+  registerSequences(
+    entityName: EntityName,
+    sequences: Record<string, Sequence<any>>
+  ) {
+    this.sequences.set(entityName, sequences);
+  }
+
+  findSequences(entityName: EntityName) {
+    return this.sequences.get(entityName);
   }
 
   /**

--- a/src/realm.ts
+++ b/src/realm.ts
@@ -17,12 +17,16 @@ export class Realm {
    */
   readonly define: Define = (
     Entity,
-    { manifest: manifester, persist: persister }
+    { manifest: manifester, persist: persister, sequences }
   ) => {
     this.storage.registerManifester(Entity.name, manifester);
 
     if (typeof persister === 'function') {
       this.storage.registerPersister(Entity.name, persister);
+    }
+
+    if (sequences) {
+      this.storage.registerSequences(Entity.name, sequences);
     }
   };
 
@@ -56,9 +60,11 @@ export class Realm {
     overrides: Partial<t.TypeOf<C>>
   ) {
     const manifester = this.storage.findManifester(Entity.name);
+    const sequences = this.storage.findSequences(Entity.name);
 
     const manifestedEntity = manifester({
       uuid: () => uuidV4(),
+      sequences,
     });
 
     const refs: ManifestedRef<any, any>[] = [];

--- a/src/realm.ts
+++ b/src/realm.ts
@@ -1,4 +1,3 @@
-import { faker } from '@faker-js/faker';
 import * as t from 'io-ts';
 import { RealmStorage } from './realm-storage';
 import { isMappedRef, ManifestedRef, MappedRef } from './ref';
@@ -57,7 +56,17 @@ export class Realm {
   ) {
     const manifester = this.storage.findManifester(Entity.name);
 
-    const manifestedEntity = manifester({ faker });
+    const manifestedEntity = manifester({
+      uuid: () => {
+        const RFC4122_TEMPLATE = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
+        const replacePlaceholders = (placeholder: string) => {
+          const random = Math.floor(Math.random() * 15);
+          const value = placeholder === 'x' ? random : (random & 0x3) | 0x8;
+          return value.toString(16);
+        };
+        return RFC4122_TEMPLATE.replace(/[xy]/g, replacePlaceholders);
+      },
+    });
 
     const refs: ManifestedRef<any, any>[] = [];
 

--- a/src/realm.ts
+++ b/src/realm.ts
@@ -1,4 +1,5 @@
 import * as t from 'io-ts';
+import { v4 as uuidV4 } from 'uuid';
 import { RealmStorage } from './realm-storage';
 import { isMappedRef, ManifestedRef, MappedRef } from './ref';
 import { Define, EntityC, Manifest, Persist } from './types';
@@ -57,15 +58,7 @@ export class Realm {
     const manifester = this.storage.findManifester(Entity.name);
 
     const manifestedEntity = manifester({
-      uuid: () => {
-        const RFC4122_TEMPLATE = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
-        const replacePlaceholders = (placeholder: string) => {
-          const random = Math.floor(Math.random() * 15);
-          const value = placeholder === 'x' ? random : (random & 0x3) | 0x8;
-          return value.toString(16);
-        };
-        return RFC4122_TEMPLATE.replace(/[xy]/g, replacePlaceholders);
-      },
+      uuid: () => uuidV4(),
     });
 
     const refs: ManifestedRef<any, any>[] = [];

--- a/src/ref.test.ts
+++ b/src/ref.test.ts
@@ -21,15 +21,15 @@ describe('Ref', () => {
       const authorManifester = jest.fn<
         t.TypeOf<typeof Author>,
         [ManifesterOptions]
-      >(({ faker }) => ({ id: faker.datatype.uuid() }));
+      >(({ uuid }) => ({ id: uuid() }));
 
       realm.define(Author, {
         manifest: authorManifester,
       });
 
       realm.define(Post, {
-        manifest: ({ faker }) => ({
-          id: faker.datatype.uuid(),
+        manifest: ({ uuid }) => ({
+          id: uuid(),
           authorId: O.some(Ref.to(Author).through(author => author.id)),
         }),
       });
@@ -57,15 +57,15 @@ describe('Ref', () => {
         const authorManifester = jest.fn<
           t.TypeOf<typeof Author>,
           [ManifesterOptions]
-        >(({ faker }) => ({ id: faker.datatype.uuid() }));
+        >(({ uuid }) => ({ id: uuid() }));
 
         realm.define(Author, {
           manifest: authorManifester,
         });
 
         realm.define(Post, {
-          manifest: ({ faker }) => ({
-            id: faker.datatype.uuid(),
+          manifest: ({ uuid }) => ({
+            id: uuid(),
             authorId: E.left(Ref.to(Author).through(author => author.id)),
           }),
         });
@@ -92,15 +92,15 @@ describe('Ref', () => {
         const authorManifester = jest.fn<
           t.TypeOf<typeof Author>,
           [ManifesterOptions]
-        >(({ faker }) => ({ id: faker.datatype.uuid() }));
+        >(({ uuid }) => ({ id: uuid() }));
 
         realm.define(Author, {
           manifest: authorManifester,
         });
 
         realm.define(Post, {
-          manifest: ({ faker }) => ({
-            id: faker.datatype.uuid(),
+          manifest: ({ uuid }) => ({
+            id: uuid(),
             authorId: E.right(Ref.to(Author).through(author => author.id)),
           }),
         });
@@ -140,15 +140,15 @@ describe('Ref', () => {
       const authorManifester = jest.fn<
         t.TypeOf<typeof Author>,
         [ManifesterOptions]
-      >(({ faker }) => ({ id: faker.datatype.uuid() }));
+      >(({ uuid }) => ({ id: uuid() }));
 
       realm.define(Author, {
         manifest: authorManifester,
       });
 
       realm.define(Post, {
-        manifest: ({ faker }) => ({
-          id: faker.datatype.uuid(),
+        manifest: ({ uuid }) => ({
+          id: uuid(),
           a: {
             u: {
               t: {

--- a/src/ref.test.ts
+++ b/src/ref.test.ts
@@ -20,7 +20,7 @@ describe('Ref', () => {
 
       const authorManifester = jest.fn<
         t.TypeOf<typeof Author>,
-        [ManifesterOptions]
+        [ManifesterOptions<unknown>]
       >(({ uuid }) => ({ id: uuid() }));
 
       realm.define(Author, {
@@ -56,7 +56,7 @@ describe('Ref', () => {
 
         const authorManifester = jest.fn<
           t.TypeOf<typeof Author>,
-          [ManifesterOptions]
+          [ManifesterOptions<unknown>]
         >(({ uuid }) => ({ id: uuid() }));
 
         realm.define(Author, {
@@ -91,7 +91,7 @@ describe('Ref', () => {
 
         const authorManifester = jest.fn<
           t.TypeOf<typeof Author>,
-          [ManifesterOptions]
+          [ManifesterOptions<unknown>]
         >(({ uuid }) => ({ id: uuid() }));
 
         realm.define(Author, {
@@ -139,7 +139,7 @@ describe('Ref', () => {
 
       const authorManifester = jest.fn<
         t.TypeOf<typeof Author>,
-        [ManifesterOptions]
+        [ManifesterOptions<unknown>]
       >(({ uuid }) => ({ id: uuid() }));
 
       realm.define(Author, {

--- a/src/sequence.test.ts
+++ b/src/sequence.test.ts
@@ -1,0 +1,25 @@
+import { identity } from 'fp-ts/function';
+import { Sequence } from './sequence';
+
+describe('Sequence', () => {
+  describe('next', () => {
+    it('yields the next item in the sequence', () => {
+      const sequence = new Sequence(identity);
+
+      expect([
+        sequence.next(),
+        sequence.next(),
+        sequence.next(),
+        sequence.next(),
+      ]).toEqual([1, 2, 3, 4]);
+    });
+  });
+
+  describe('take', () => {
+    it('yields the specified number of items from the sequence', () => {
+      const sequence = new Sequence(identity);
+
+      expect(sequence.take(3)).toEqual([1, 2, 3]);
+    });
+  });
+});

--- a/src/sequence.ts
+++ b/src/sequence.ts
@@ -1,10 +1,12 @@
 import { pipe } from 'fp-ts/function';
 import * as NEA from 'fp-ts/NonEmptyArray';
 
+export type SequenceProducer<T> = (n: number) => T;
+
 export class Sequence<T> {
   private counter = 1;
 
-  constructor(private readonly produce: (n: number) => T) {}
+  constructor(private readonly produce: SequenceProducer<T>) {}
 
   /**
    * Returns the next item in the sequence.

--- a/src/sequence.ts
+++ b/src/sequence.ts
@@ -1,12 +1,10 @@
 import { pipe } from 'fp-ts/function';
 import * as NEA from 'fp-ts/NonEmptyArray';
 
-export type SequenceProducer<T> = (n: number) => T;
-
 export class Sequence<T> {
   private counter = 1;
 
-  constructor(private readonly produce: SequenceProducer<T>) {}
+  constructor(private readonly produce: (n: number) => T) {}
 
   /**
    * Returns the next item in the sequence.

--- a/src/sequence.ts
+++ b/src/sequence.ts
@@ -1,0 +1,21 @@
+import { pipe } from 'fp-ts/function';
+import * as NEA from 'fp-ts/NonEmptyArray';
+
+export class Sequence<T> {
+  private counter = 1;
+
+  constructor(private readonly produce: (n: number) => T) {}
+
+  next() {
+    return this.produce(this.counter++);
+  }
+
+  take(n: number) {
+    return [
+      ...pipe(
+        NEA.range(1, n),
+        NEA.map(() => this.next())
+      ),
+    ];
+  }
+}

--- a/src/sequence.ts
+++ b/src/sequence.ts
@@ -6,10 +6,18 @@ export class Sequence<T> {
 
   constructor(private readonly produce: (n: number) => T) {}
 
+  /**
+   * Returns the next item in the sequence.
+   */
   next() {
     return this.produce(this.counter++);
   }
 
+  /**
+   * Returns the next _n_ items in the sequence.
+   *
+   * @param n The number of items to take from the sequence.
+   */
   take(n: number) {
     return [
       ...pipe(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import * as t from 'io-ts';
-import { Sequence, SequenceProducer } from './sequence';
+import { Sequence } from './sequence';
 
 export type EntityName = string;
 
@@ -26,16 +26,12 @@ export type Manifester<T, TSequences> = (
 export type Persister<T> = (entity: T) => Promise<T>;
 
 export interface Sequences {
-  [name: string]: SequenceProducer<unknown>;
+  [name: string]: Sequence<unknown>;
 }
-
-export type Mapped<T extends Sequences> = {
-  [K in keyof T]: Sequence<ReturnType<T[K]>>;
-};
 
 export interface DefineOptions<T, TSequences extends Sequences> {
   sequences?: TSequences;
-  manifest: Manifester<T, Mapped<TSequences>>;
+  manifest: Manifester<T, TSequences>;
   persist?: Persister<T>;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-import { Faker } from '@faker-js/faker';
 import * as t from 'io-ts';
 
 export type EntityName = string;
@@ -9,7 +8,7 @@ export type EntityC = t.Any;
  * The options passed to a `Manifester`.
  */
 export interface ManifesterOptions {
-  faker: Faker;
+  uuid: () => string;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import * as t from 'io-ts';
+import { Sequence } from './sequence';
 
 export type EntityName = string;
 
@@ -7,28 +8,36 @@ export type EntityC = t.Any;
 /**
  * The options passed to a `Manifester`.
  */
-export interface ManifesterOptions {
+export interface ManifesterOptions<TSequences> {
   uuid: () => string;
+  sequences: TSequences;
 }
 
 /**
  * A manifester for an entity of type `T`.
  */
-export type Manifester<T> = (options: ManifesterOptions) => T;
+export type Manifester<T, TSequences> = (
+  options: ManifesterOptions<TSequences>
+) => T;
 
 /**
  * A persister for an entity of type `T`.
  */
 export type Persister<T> = (entity: T) => Promise<T>;
 
-export interface DefineOptions<T> {
-  manifest: Manifester<T>;
+export interface Sequences {
+  [name: string]: Sequence<unknown>;
+}
+
+export interface DefineOptions<T, TSequences extends Sequences> {
+  sequences?: TSequences;
+  manifest: Manifester<T, TSequences>;
   persist?: Persister<T>;
 }
 
-export type Define = <C extends EntityC>(
+export type Define = <C extends EntityC, TSequences extends Sequences>(
   Entity: C,
-  options: DefineOptions<t.TypeOf<C>>
+  options: DefineOptions<t.TypeOf<C>, TSequences>
 ) => void;
 
 export type Manifest = <C extends EntityC>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import * as t from 'io-ts';
-import { Sequence } from './sequence';
+import { Sequence, SequenceProducer } from './sequence';
 
 export type EntityName = string;
 
@@ -26,12 +26,16 @@ export type Manifester<T, TSequences> = (
 export type Persister<T> = (entity: T) => Promise<T>;
 
 export interface Sequences {
-  [name: string]: Sequence<unknown>;
+  [name: string]: SequenceProducer<unknown>;
 }
+
+export type Mapped<T extends Sequences> = {
+  [K in keyof T]: Sequence<ReturnType<T[K]>>;
+};
 
 export interface DefineOptions<T, TSequences extends Sequences> {
   sequences?: TSequences;
-  manifest: Manifester<T, TSequences>;
+  manifest: Manifester<T, Mapped<TSequences>>;
   persist?: Persister<T>;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -466,11 +466,6 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@faker-js/faker@7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-7.3.0.tgz#a508df35ded585c4e071cb5d9d7c89623c837fae"
-  integrity sha512-1W0PZezq2rxlAssoWemi9gFRD8IQxvf0FPL5Km3TOmGHFG7ib0TbFBJ0yC7D/1NsxunjNTK6WjUXV8ao/mKZ5w==
-
 "@gar/promisify@^1.0.1":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
@@ -861,6 +856,11 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
+
+"@types/uuid@8.3.4":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
 
 "@types/yargs-parser@*":
   version "21.0.0"
@@ -3031,6 +3031,11 @@ util-deprecate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
+uuid@8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-to-istanbul@^9.0.1:
   version "9.0.1"


### PR DESCRIPTION
This PR removes Faker as a dependency from Thauamaturge.

Instead, we have replaced it with a simpler constructs:
- A UUID generator for when true uniqueness is needed
- Sequences for creating variance in test data