### PR TITLE
Add context to persisters

### DIFF
--- a/packages/core/src/realm-storage.ts
+++ b/packages/core/src/realm-storage.ts
@@ -18,7 +18,7 @@ import { Entity, EntityName, Manifester, Persister } from './types';
 export class RealmStorage {
   private readonly entities = new Map<EntityName, Entity>();
   private readonly manifesters = new Map<EntityName, Manifester<any, any>>();
-  private readonly persisters = new Map<EntityName, Persister<any>>();
+  private readonly persisters = new Map<EntityName, Persister<any, any>>();
   private readonly sequences = new Map<
     EntityName,
     Record<string, Sequence<any>>

--- a/packages/core/src/realm-storage.ts
+++ b/packages/core/src/realm-storage.ts
@@ -83,7 +83,7 @@ export class RealmStorage {
    * @param entityName The name of the entity to register the persister under.
    * @param persister The persister to register.
    */
-  registerPersister(entityName: EntityName, persister: Persister<any>) {
+  registerPersister(entityName: EntityName, persister: Persister<any, any>) {
     if (this.persisters.has(entityName)) {
       throw new PersisterAlreadyRegisteredError(entityName);
     }

--- a/packages/core/src/realm.ts
+++ b/packages/core/src/realm.ts
@@ -3,7 +3,13 @@ import { topologicallyBatchEntities } from './entity-graph-utils';
 import { isUnknownRecord } from './is-unknown-record';
 import { RealmStorage } from './realm-storage';
 import { isMappedRef, ManifestedRef, MappedRef } from './ref';
-import { Define, Entity, Manifest } from './types';
+import { Entity, Manifest, Manifester, Persister, Sequences } from './types';
+
+export interface DefineOptions<T, TSequences extends Sequences, TContext> {
+  sequences?: TSequences;
+  manifest: Manifester<T, TSequences>;
+  persist?: Persister<T, TContext>;
+}
 
 /**
  * A realm is an isolated environment that entities may be registered with.
@@ -16,10 +22,14 @@ export class Realm<TContext> {
   /**
    * Defines an entity in the realm using the specified manifester and persister.
    */
-  readonly define: Define = (
-    Entity,
-    { manifest: manifester, persist: persister, sequences }
-  ) => {
+  readonly define = <T, TSequences extends Sequences>(
+    Entity: Entity,
+    {
+      manifest: manifester,
+      persist: persister,
+      sequences,
+    }: DefineOptions<T, TSequences, TContext>
+  ): void => {
     this.storage.registerEntity(Entity);
     this.storage.registerManifester(Entity.name, manifester);
 

--- a/packages/core/src/realm.ts
+++ b/packages/core/src/realm.ts
@@ -57,7 +57,7 @@ export class Realm {
    * @param Entity The entity to persist.
    * @param overrides The overrides to pass to the persister.
    */
-  readonly persist: Persist = async (Entity, overrides = {}) => {
+  readonly persist: Persist = async (Entity, overrides = {}, context) => {
     const persister = this.storage.findPersister(Entity.name);
 
     const { manifestedEntity, refs } = this.manifestWithRefs(Entity, overrides);
@@ -66,7 +66,7 @@ export class Realm {
       await this.persistRef(ref);
     }
 
-    return persister(manifestedEntity);
+    return persister(manifestedEntity, context);
   };
 
   readonly persistLeaves: PersistLeaves = async () => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -25,7 +25,10 @@ export type Manifester<T, TSequences> = (
 /**
  * A persister for an entity of type `T`.
  */
-export type Persister<T> = (entity: T) => Promise<T>;
+export type Persister<T, TContext = unknown> = (
+  entity: T,
+  context?: TContext
+) => Promise<T>;
 
 export interface Sequences {
   [name: string]: Sequence<unknown>;
@@ -44,6 +47,10 @@ export type Define = <T, TSequences extends Sequences>(
 
 export type Manifest = <T>(Entity: Entity, overrides?: Partial<T>) => T;
 
-export type Persist = <T>(Entity: Entity, overrides?: Partial<T>) => Promise<T>;
+export type Persist = <T, TContext = unknown>(
+  Entity: Entity,
+  overrides?: Partial<T>,
+  context?: TContext
+) => Promise<T>;
 
 export type PersistLeaves = () => Promise<unknown[]>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -34,15 +34,4 @@ export interface Sequences {
   [name: string]: Sequence<unknown>;
 }
 
-export interface DefineOptions<T, TSequences extends Sequences, TContext> {
-  sequences?: TSequences;
-  manifest: Manifester<T, TSequences>;
-  persist?: Persister<T, TContext>;
-}
-
-export type Define = <T, TSequences extends Sequences, TContext>(
-  Entity: Entity,
-  options: DefineOptions<T, TSequences, TContext>
-) => void;
-
 export type Manifest = <T>(Entity: Entity, overrides?: Partial<T>) => T;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -25,32 +25,24 @@ export type Manifester<T, TSequences> = (
 /**
  * A persister for an entity of type `T`.
  */
-export type Persister<T, TContext = unknown> = (
+export type Persister<T, TContext> = (
   entity: T,
-  context?: TContext
+  context: TContext
 ) => Promise<T>;
 
 export interface Sequences {
   [name: string]: Sequence<unknown>;
 }
 
-export interface DefineOptions<T, TSequences extends Sequences> {
+export interface DefineOptions<T, TSequences extends Sequences, TContext> {
   sequences?: TSequences;
   manifest: Manifester<T, TSequences>;
-  persist?: Persister<T>;
+  persist?: Persister<T, TContext>;
 }
 
-export type Define = <T, TSequences extends Sequences>(
+export type Define = <T, TSequences extends Sequences, TContext>(
   Entity: Entity,
-  options: DefineOptions<T, TSequences>
+  options: DefineOptions<T, TSequences, TContext>
 ) => void;
 
 export type Manifest = <T>(Entity: Entity, overrides?: Partial<T>) => T;
-
-export type Persist = <T, TContext = unknown>(
-  Entity: Entity,
-  overrides?: Partial<T>,
-  context?: TContext
-) => Promise<T>;
-
-export type PersistLeaves = () => Promise<unknown[]>;

--- a/packages/io-ts/src/__tests__/database.ts
+++ b/packages/io-ts/src/__tests__/database.ts
@@ -1,0 +1,45 @@
+interface Car {
+  make: string;
+  model: string;
+}
+
+interface Kingdom {
+  name: string;
+}
+
+interface Phylum {
+  kingdom: string;
+  name: string;
+}
+
+interface Class {
+  phylum: string;
+  name: string;
+}
+
+interface Author {
+  id: string;
+  name: string;
+}
+
+interface Post {
+  id: string;
+  author_id: string;
+  title: string;
+}
+
+interface Comment {
+  id: string;
+  post_id: string;
+  username: string;
+}
+
+export interface Database {
+  car: Car;
+  kingdom: Kingdom;
+  phylum: Phylum;
+  class: Class;
+  author: Author;
+  post: Post;
+  comment: Comment;
+}

--- a/packages/io-ts/src/__tests__/database.ts
+++ b/packages/io-ts/src/__tests__/database.ts
@@ -1,3 +1,6 @@
+import SqliteDatabase from 'better-sqlite3';
+import { Kysely, SqliteDialect, sql } from 'kysely';
+
 interface Car {
   make: string;
   model: string;
@@ -43,3 +46,62 @@ export interface Database {
   post: Post;
   comment: Comment;
 }
+
+export const setupDatabase = async () => {
+  const db = new Kysely<Database>({
+    dialect: new SqliteDialect({
+      database: async () => new SqliteDatabase(':memory:'),
+    }),
+  });
+
+  await sql`pragma foreign_keys = on`.execute(db);
+
+  await db.schema
+    .createTable('car')
+    .addColumn('make', 'text', col => col.notNull())
+    .addColumn('model', 'text', col => col.notNull())
+    .execute();
+
+  await db.schema
+    .createTable('kingdom')
+    .addColumn('name', 'text', col => col.primaryKey())
+    .execute();
+
+  await db.schema
+    .createTable('phylum')
+    .addColumn('kingdom', 'text', col => col.notNull())
+    .addColumn('name', 'text', col => col.primaryKey())
+    .addForeignKeyConstraint('phylum_kingdom', ['kingdom'], 'kingdom', ['name'])
+    .execute();
+
+  await db.schema
+    .createTable('class')
+    .addColumn('phylum', 'text', col => col.notNull())
+    .addColumn('name', 'text', col => col.primaryKey())
+    .addForeignKeyConstraint('class_phylum', ['phylum'], 'phylum', ['name'])
+    .execute();
+
+  await db.schema
+    .createTable('author')
+    .addColumn('id', 'text', col => col.primaryKey())
+    .addColumn('name', 'text', col => col.notNull())
+    .execute();
+
+  await db.schema
+    .createTable('post')
+    .addColumn('id', 'text', col => col.primaryKey())
+    .addColumn('author_id', 'text', col => col.notNull())
+    .addColumn('title', 'text', col => col.notNull())
+    .addForeignKeyConstraint('post_author_id', ['author_id'], 'author', ['id'])
+    .execute();
+
+  await db.schema
+    .createTable('comment')
+    .addColumn('id', 'text', col => col.primaryKey())
+    .addColumn('post_id', 'text', col => col.notNull())
+    .addColumn('username', 'text', col => col.notNull())
+    .addForeignKeyConstraint('comment_post_id', ['post_id'], 'post', ['id'])
+    .execute();
+
+  return { db };
+};

--- a/packages/io-ts/src/__tests__/fixtures.ts
+++ b/packages/io-ts/src/__tests__/fixtures.ts
@@ -5,6 +5,11 @@ import { Transaction } from 'kysely';
 import { Database } from './database';
 import { Sequence } from '@thaumaturgy/core';
 
+export const Car = t.type({
+  make: t.string,
+  model: t.string,
+});
+
 export const Kingdom = t.type({ name: t.string }, 'Kingdom');
 
 export const Phylum = t.type({ kingdom: t.string, name: t.string }, 'Phylum');
@@ -36,6 +41,21 @@ export interface Context {
 }
 
 export const define = (realm: Realm<Context>) => {
+  realm.define(Car, {
+    manifest: () => ({
+      make: 'Honda',
+      model: 'Civic',
+    }),
+    persist: async (car, { tx }) => {
+      await tx
+        .insertInto('car')
+        .values({ make: car.make, model: car.model })
+        .execute();
+
+      return car;
+    },
+  });
+
   realm.define(Kingdom, {
     manifest: () => ({ name: 'Animalia' }),
     persist: async (kingdom, { tx }) => {

--- a/packages/io-ts/src/__tests__/fixtures.ts
+++ b/packages/io-ts/src/__tests__/fixtures.ts
@@ -1,0 +1,56 @@
+import * as t from 'io-ts';
+import { Realm } from '../realm';
+import { Ref } from '../ref';
+import { Transaction } from 'kysely';
+import { Database } from './database';
+
+const Kingdom = t.type({ name: t.string });
+
+const Phylum = t.type({ kingdom: t.string, name: t.string });
+
+const Class = t.type({ phylum: t.string, name: t.string });
+
+export interface Context {
+  tx: Transaction<Database>;
+}
+
+export const define = (realm: Realm<Context>) => {
+  realm.define(Kingdom, {
+    manifest: () => ({ name: 'Animalia' }),
+    persist: async (kingdom, { tx }) => {
+      await tx.insertInto('kingdom').values({ name: kingdom.name }).execute();
+
+      return kingdom;
+    },
+  });
+
+  realm.define(Phylum, {
+    manifest: () => ({
+      kingdom: Ref.to(Kingdom).through(kingdom => kingdom.name),
+      name: 'Chordata',
+    }),
+    persist: async (phylum, { tx }) => {
+      await tx
+        .insertInto('phylum')
+        .values({ kingdom: phylum.kingdom, name: phylum.name })
+        .execute();
+
+      return phylum;
+    },
+  });
+
+  realm.define(Class, {
+    manifest: () => ({
+      phylum: Ref.to(Phylum).through(phylum => phylum.name),
+      name: 'Mammalia',
+    }),
+    persist: async (class_, { tx }) => {
+      await tx
+        .insertInto('class')
+        .values({ phylum: class_.phylum, name: class_.name })
+        .execute();
+
+      return class_;
+    },
+  });
+};

--- a/packages/io-ts/src/__tests__/realm.define.test.ts
+++ b/packages/io-ts/src/__tests__/realm.define.test.ts
@@ -47,6 +47,8 @@ describe('Realm', () => {
 
     describe('when `persist` is invoked', () => {
       it('calls the persister', async () => {
+        const context = {};
+
         const realm = new Realm();
 
         const persister = vi.fn(movie => Promise.resolve(movie));
@@ -56,12 +58,14 @@ describe('Realm', () => {
           persist: persister,
         });
 
-        await realm.persist(Movie);
+        await realm.persist(Movie, context);
 
         expect(persister).toHaveBeenCalledTimes(1);
       });
 
       it('passes the manifested entity to the persister', async () => {
+        const context = {};
+
         const realm = new Realm();
 
         const persister = vi.fn(movie => Promise.resolve(movie));
@@ -71,7 +75,7 @@ describe('Realm', () => {
           persist: persister,
         });
 
-        await realm.persist(Movie);
+        await realm.persist(Movie, context);
 
         expect(persister).toHaveBeenCalledWith(
           {
@@ -84,6 +88,8 @@ describe('Realm', () => {
 
       describe('with a `context` parameter', () => {
         it('passes the context to the persister', async () => {
+          const context = { a: 'hello', b: 'world' };
+
           const realm = new Realm();
 
           const persister = vi.fn(movie => Promise.resolve(movie));
@@ -93,15 +99,12 @@ describe('Realm', () => {
             persist: persister,
           });
 
-          await realm.persist(Movie, {}, { a: 'hello', b: 'world' });
+          await realm.persist(Movie, context, {});
 
-          expect(persister).toHaveBeenCalledWith(
-            {
-              title: 'Arrival',
-              year: 2017 as t.Int,
-            },
-            { a: 'hello', b: 'world' }
-          );
+          expect(persister).toHaveBeenCalledWith(context, {
+            title: 'Arrival',
+            year: 2017 as t.Int,
+          });
         });
       });
     });

--- a/packages/io-ts/src/__tests__/realm.define.test.ts
+++ b/packages/io-ts/src/__tests__/realm.define.test.ts
@@ -73,9 +73,35 @@ describe('Realm', () => {
 
         await realm.persist(Movie);
 
-        expect(persister).toHaveBeenCalledWith({
-          title: 'Arrival',
-          year: 2017 as t.Int,
+        expect(persister).toHaveBeenCalledWith(
+          {
+            title: 'Arrival',
+            year: 2017 as t.Int,
+          },
+          undefined
+        );
+      });
+
+      describe('with a `context` parameter', () => {
+        it('passes the context to the persister', async () => {
+          const realm = new Realm();
+
+          const persister = vi.fn(movie => Promise.resolve(movie));
+
+          realm.define(Movie, {
+            manifest: () => ({ title: 'Arrival', year: 2017 as t.Int }),
+            persist: persister,
+          });
+
+          await realm.persist(Movie, {}, { a: 'hello', b: 'world' });
+
+          expect(persister).toHaveBeenCalledWith(
+            {
+              title: 'Arrival',
+              year: 2017 as t.Int,
+            },
+            { a: 'hello', b: 'world' }
+          );
         });
       });
     });

--- a/packages/io-ts/src/__tests__/realm.define.test.ts
+++ b/packages/io-ts/src/__tests__/realm.define.test.ts
@@ -82,7 +82,7 @@ describe('Realm', () => {
             title: 'Arrival',
             year: 2017 as t.Int,
           },
-          undefined
+          context
         );
       });
 
@@ -90,7 +90,7 @@ describe('Realm', () => {
         it('passes the context to the persister', async () => {
           const context = { a: 'hello', b: 'world' };
 
-          const realm = new Realm();
+          const realm = new Realm<typeof context>();
 
           const persister = vi.fn(movie => Promise.resolve(movie));
 
@@ -101,10 +101,13 @@ describe('Realm', () => {
 
           await realm.persist(Movie, context, {});
 
-          expect(persister).toHaveBeenCalledWith(context, {
-            title: 'Arrival',
-            year: 2017 as t.Int,
-          });
+          expect(persister).toHaveBeenCalledWith(
+            {
+              title: 'Arrival',
+              year: 2017 as t.Int,
+            },
+            context
+          );
         });
       });
     });

--- a/packages/io-ts/src/__tests__/realm.persist-leaves.test.ts
+++ b/packages/io-ts/src/__tests__/realm.persist-leaves.test.ts
@@ -1,34 +1,10 @@
-import { Sequence } from '@thaumaturgy/core';
-import * as t from 'io-ts';
-import assert from 'node:assert';
 import SqliteDatabase from 'better-sqlite3';
 import { Kysely, SqliteDialect, sql } from 'kysely';
+import assert from 'node:assert';
 import { describe, expect, it } from 'vitest';
 import { Realm } from '../realm';
-import { Ref } from '../ref';
-
-interface Author {
-  id: string;
-  name: string;
-}
-
-interface Post {
-  id: string;
-  author_id: string;
-  title: string;
-}
-
-interface Comment {
-  id: string;
-  post_id: string;
-  username: string;
-}
-
-interface Database {
-  author: Author;
-  post: Post;
-  comment: Comment;
-}
+import { Database } from './database';
+import { Comment, Context } from './fixtures';
 
 describe('Realm', () => {
   describe('persistLeaves', () => {
@@ -43,26 +19,6 @@ describe('Realm', () => {
     };
 
     describe('for an entity hierarchy with randomly-generated IDs', () => {
-      const Author = t.type({ id: t.string, name: t.string }, 'Author');
-
-      const Post = t.type(
-        {
-          id: t.string,
-          authorId: t.string,
-          title: t.string,
-        },
-        'Post'
-      );
-
-      const Comment = t.type(
-        {
-          id: t.string,
-          postId: t.string,
-          username: t.string,
-        },
-        'Comment'
-      );
-
       const performSetup = async () => {
         const { db } = await setupDatabase();
 
@@ -94,71 +50,7 @@ describe('Realm', () => {
           ])
           .execute();
 
-        const realm = new Realm();
-
-        realm.define(Author, {
-          sequences: {
-            names: new Sequence(n => `Author ${n}` as const),
-          },
-          manifest: ({ uuid, sequences }) => ({
-            id: uuid(),
-            name: sequences.names.next(),
-          }),
-          persist: async author => {
-            await db
-              .insertInto('author')
-              .values({ id: author.id, name: author.name })
-              .execute();
-
-            return author;
-          },
-        });
-
-        realm.define(Post, {
-          sequences: {
-            titles: new Sequence(n => `Post ${n}` as const),
-          },
-          manifest: ({ uuid, sequences }) => ({
-            id: uuid(),
-            authorId: Ref.to(Author).through(author => author.id),
-            title: sequences.titles.next(),
-          }),
-          persist: async post => {
-            await db
-              .insertInto('post')
-              .values({
-                id: post.id,
-                author_id: post.authorId,
-                title: post.title,
-              })
-              .execute();
-
-            return post;
-          },
-        });
-
-        realm.define(Comment, {
-          sequences: {
-            usernames: new Sequence(n => `user${n}` as const),
-          },
-          manifest: ({ uuid, sequences }) => ({
-            id: uuid(),
-            postId: Ref.to(Post).through(post => post.id),
-            username: sequences.usernames.next(),
-          }),
-          persist: async comment => {
-            await db
-              .insertInto('comment')
-              .values({
-                id: comment.id,
-                post_id: comment.postId,
-                username: comment.username,
-              })
-              .execute();
-
-            return comment;
-          },
-        });
+        const realm = new Realm<Context>();
 
         return { db, realm };
       };
@@ -166,57 +58,59 @@ describe('Realm', () => {
       it('persists an instance of each entity in the hierarchy', async () => {
         const { db, realm } = await performSetup();
 
-        const leaves = await realm.persistLeaves();
+        await db.transaction().execute(async tx => {
+          const leaves = await realm.persistLeaves({ tx });
 
-        expect(leaves).toHaveLength(1);
+          expect(leaves).toHaveLength(1);
 
-        const comment = leaves[0];
-        expect(Comment.is(comment)).toBe(true);
-        assert.ok(Comment.is(comment));
+          const comment = leaves[0];
+          expect(Comment.is(comment)).toBe(true);
+          assert.ok(Comment.is(comment));
 
-        expect(comment).toEqual({
-          id: expect.any(String),
-          postId: expect.any(String),
-          username: 'user1',
-        });
-
-        const authorsInDatabase = await db
-          .selectFrom('author')
-          .selectAll()
-          .execute();
-
-        expect(authorsInDatabase).toEqual([
-          {
+          expect(comment).toEqual({
             id: expect.any(String),
-            name: 'Author 1',
-          },
-        ]);
+            postId: expect.any(String),
+            username: 'user1',
+          });
 
-        const postsInDatabase = await db
-          .selectFrom('post')
-          .selectAll()
-          .execute();
+          const authorsInDatabase = await db
+            .selectFrom('author')
+            .selectAll()
+            .execute();
 
-        expect(postsInDatabase).toEqual([
-          {
-            id: comment.postId,
-            author_id: authorsInDatabase[0]?.id,
-            title: 'Post 1',
-          },
-        ]);
+          expect(authorsInDatabase).toEqual([
+            {
+              id: expect.any(String),
+              name: 'Author 1',
+            },
+          ]);
 
-        const commentsInDatabase = await db
-          .selectFrom('comment')
-          .selectAll()
-          .execute();
+          const postsInDatabase = await db
+            .selectFrom('post')
+            .selectAll()
+            .execute();
 
-        expect(commentsInDatabase).toEqual([
-          {
-            id: comment.id,
-            post_id: comment.postId,
-            username: comment.username,
-          },
-        ]);
+          expect(postsInDatabase).toEqual([
+            {
+              id: comment.postId,
+              author_id: authorsInDatabase[0]?.id,
+              title: 'Post 1',
+            },
+          ]);
+
+          const commentsInDatabase = await db
+            .selectFrom('comment')
+            .selectAll()
+            .execute();
+
+          expect(commentsInDatabase).toEqual([
+            {
+              id: comment.id,
+              post_id: comment.postId,
+              username: comment.username,
+            },
+          ]);
+        });
       });
     });
   });

--- a/packages/io-ts/src/__tests__/realm.persist.test.ts
+++ b/packages/io-ts/src/__tests__/realm.persist.test.ts
@@ -1,137 +1,71 @@
-import SqliteDatabase from 'better-sqlite3';
-import * as t from 'io-ts';
-import { Kysely, SqliteDialect, sql } from 'kysely';
 import { describe, expect, it } from 'vitest';
 import { Realm } from '../realm';
-import { Database } from './database';
-import { Class, Comment, Context, define } from './fixtures';
+import { setupDatabase } from './database';
+import { Car, Class, Comment, Context, define } from './fixtures';
 
 describe('Realm', () => {
+  const performSetup = async () => {
+    const { db } = await setupDatabase();
+
+    const realm = new Realm<Context>();
+
+    define(realm);
+
+    return { db, realm };
+  };
+
   describe('persist', () => {
-    const setupDatabase = async () => {
-      const db = new Kysely<Database>({
-        dialect: new SqliteDialect({
-          database: async () => new SqliteDatabase(':memory:'),
-        }),
-      });
-
-      return { db };
-    };
-
-    const Car = t.type({
-      make: t.string,
-      model: t.string,
-    });
-
-    const performSetup = async () => {
-      const { db } = await setupDatabase();
-
-      await db.schema
-        .createTable('car')
-        .addColumn('make', 'text', col => col.notNull())
-        .addColumn('model', 'text', col => col.notNull())
-        .execute();
-
-      const context = { db };
-
-      const realm = new Realm<typeof context>();
-
-      realm.define(Car, {
-        manifest: () => ({
-          make: 'Honda',
-          model: 'Civic',
-        }),
-        persist: async car => {
-          await db
-            .insertInto('car')
-            .values({ make: car.make, model: car.model })
-            .execute();
-
-          return car;
-        },
-      });
-
-      return { db, realm, context };
-    };
-
     describe('with no overrides', () => {
       it('persists an instance of the provided type', async () => {
-        const { db, realm, context } = await performSetup();
+        const { db, realm } = await performSetup();
 
-        const persisted = await realm.persist(Car, context);
+        await db.transaction().execute(async tx => {
+          const persisted = await realm.persist(Car, { tx });
 
-        expect(persisted).toEqual({
-          make: 'Honda',
-          model: 'Civic',
+          expect(persisted).toEqual({
+            make: 'Honda',
+            model: 'Civic',
+          });
+
+          const carFromDatabase = await tx
+            .selectFrom('car')
+            .select(['make', 'model'])
+            .executeTakeFirst();
+
+          expect(carFromDatabase).toEqual(persisted);
         });
-
-        const carFromDatabase = await db
-          .selectFrom('car')
-          .select(['make', 'model'])
-          .executeTakeFirst();
-
-        expect(carFromDatabase).toEqual(persisted);
       });
     });
 
     describe('with overrides', () => {
       it('persists an instance of the provided type with the overrides applied', async () => {
-        const { db, realm, context } = await performSetup();
+        const { db, realm } = await performSetup();
 
-        const persisted = await realm.persist(Car, context, {
-          model: 'CRV',
+        await db.transaction().execute(async tx => {
+          const persisted = await realm.persist(
+            Car,
+            { tx },
+            {
+              model: 'CRV',
+            }
+          );
+
+          expect(persisted).toEqual({
+            make: 'Honda',
+            model: 'CRV',
+          });
+
+          const carFromDatabase = await tx
+            .selectFrom('car')
+            .select(['make', 'model'])
+            .executeTakeFirst();
+
+          expect(carFromDatabase).toEqual(persisted);
         });
-
-        expect(persisted).toEqual({
-          make: 'Honda',
-          model: 'CRV',
-        });
-
-        const carFromDatabase = await db
-          .selectFrom('car')
-          .select(['make', 'model'])
-          .executeTakeFirst();
-
-        expect(carFromDatabase).toEqual(persisted);
       });
     });
 
     describe('for an entity hierarchy', () => {
-      const performSetup = async () => {
-        const { db } = await setupDatabase();
-
-        await sql`pragma foreign_keys = on`.execute(db);
-
-        await db.schema
-          .createTable('kingdom')
-          .addColumn('name', 'text', col => col.primaryKey())
-          .execute();
-
-        await db.schema
-          .createTable('phylum')
-          .addColumn('kingdom', 'text', col => col.notNull())
-          .addColumn('name', 'text', col => col.primaryKey())
-          .addForeignKeyConstraint('phylum_kingdom', ['kingdom'], 'kingdom', [
-            'name',
-          ])
-          .execute();
-
-        await db.schema
-          .createTable('class')
-          .addColumn('phylum', 'text', col => col.notNull())
-          .addColumn('name', 'text', col => col.primaryKey())
-          .addForeignKeyConstraint('class_phylum', ['phylum'], 'phylum', [
-            'name',
-          ])
-          .execute();
-
-        const realm = new Realm<Context>();
-
-        define(realm);
-
-        return { db, realm };
-      };
-
       it('persists an instance of each entity in the hierarchy', async () => {
         const { db, realm } = await performSetup();
 
@@ -171,44 +105,6 @@ describe('Realm', () => {
     });
 
     describe('for an entity hierarchy with randomly-generated IDs', () => {
-      const performSetup = async () => {
-        const { db } = await setupDatabase();
-
-        await sql`pragma foreign_keys = on`.execute(db);
-
-        await db.schema
-          .createTable('author')
-          .addColumn('id', 'text', col => col.primaryKey())
-          .addColumn('name', 'text', col => col.notNull())
-          .execute();
-
-        await db.schema
-          .createTable('post')
-          .addColumn('id', 'text', col => col.primaryKey())
-          .addColumn('author_id', 'text', col => col.notNull())
-          .addColumn('title', 'text', col => col.notNull())
-          .addForeignKeyConstraint('post_author_id', ['author_id'], 'author', [
-            'id',
-          ])
-          .execute();
-
-        await db.schema
-          .createTable('comment')
-          .addColumn('id', 'text', col => col.primaryKey())
-          .addColumn('post_id', 'text', col => col.notNull())
-          .addColumn('username', 'text', col => col.notNull())
-          .addForeignKeyConstraint('comment_post_id', ['post_id'], 'post', [
-            'id',
-          ])
-          .execute();
-
-        const realm = new Realm<Context>();
-
-        define(realm);
-
-        return { db, realm };
-      };
-
       it('persists an instance of each entity in the hierarchy', async () => {
         const { db, realm } = await performSetup();
 

--- a/packages/io-ts/src/realm.ts
+++ b/packages/io-ts/src/realm.ts
@@ -4,7 +4,7 @@ import {
   Sequences,
 } from '@thaumaturgy/core';
 import * as t from 'io-ts';
-import { EntityC, Manifest } from './types';
+import { EntityC } from './types';
 
 /**
  * A realm is an isolated environment that entities may be registered with.
@@ -37,7 +37,10 @@ export class Realm<TContext> {
    * @param Entity The entity to manifest.
    * @param overrides The overrides to pass to the manifester.
    */
-  readonly manifest: Manifest = (Entity, overrides = {}) => {
+  readonly manifest = <C extends EntityC>(
+    Entity: C,
+    overrides: Partial<t.TypeOf<C>> = {}
+  ): t.TypeOf<C> => {
     return this.realm.manifest({ C: Entity, name: Entity.name }, overrides);
   };
 

--- a/packages/io-ts/src/realm.ts
+++ b/packages/io-ts/src/realm.ts
@@ -1,18 +1,26 @@
-import { Realm as BackingRealm, PersistLeaves } from '@thaumaturgy/core';
-import { Define, Manifest, Persist } from './types';
+import {
+  Realm as BackingRealm,
+  DefineOptions,
+  Sequences,
+} from '@thaumaturgy/core';
+import * as t from 'io-ts';
+import { EntityC, Manifest } from './types';
 
 /**
  * A realm is an isolated environment that entities may be registered with.
  *
  * Entity names must be unique within a realm.
  */
-export class Realm {
-  private readonly realm = new BackingRealm();
+export class Realm<TContext> {
+  private readonly realm = new BackingRealm<TContext>();
 
   /**
    * Defines an entity in the realm using the specified manifester and persister.
    */
-  readonly define: Define = (Entity, options) => {
+  readonly define = <C extends EntityC, TSequences extends Sequences>(
+    Entity: C,
+    options: DefineOptions<t.TypeOf<C>, TSequences, TContext>
+  ) => {
     this.realm.define({ C: Entity, name: Entity.name }, options);
   };
 
@@ -37,9 +45,14 @@ export class Realm {
    * Persists an instance of the specified entity.
    *
    * @param Entity The entity to persist.
+   * @param context The context to pass to the persister.
    * @param overrides The overrides to pass to the persister.
    */
-  readonly persist: Persist = async (Entity, overrides = {}, context) => {
+  readonly persist = async <C extends EntityC>(
+    Entity: C,
+    context: TContext,
+    overrides: Partial<t.TypeOf<C>> = {}
+  ): Promise<t.TypeOf<C>> => {
     return this.realm.persist(
       { C: Entity, name: Entity.name },
       overrides,
@@ -47,7 +60,7 @@ export class Realm {
     );
   };
 
-  readonly persistLeaves: PersistLeaves = async () => {
-    return this.realm.persistLeaves();
+  readonly persistLeaves = async (context: TContext) => {
+    return this.realm.persistLeaves(context);
   };
 }

--- a/packages/io-ts/src/realm.ts
+++ b/packages/io-ts/src/realm.ts
@@ -39,8 +39,12 @@ export class Realm {
    * @param Entity The entity to persist.
    * @param overrides The overrides to pass to the persister.
    */
-  readonly persist: Persist = async (Entity, overrides = {}) => {
-    return this.realm.persist({ C: Entity, name: Entity.name }, overrides);
+  readonly persist: Persist = async (Entity, overrides = {}, context) => {
+    return this.realm.persist(
+      { C: Entity, name: Entity.name },
+      overrides,
+      context
+    );
   };
 
   readonly persistLeaves: PersistLeaves = async () => {

--- a/packages/io-ts/src/types.ts
+++ b/packages/io-ts/src/types.ts
@@ -1,26 +1,3 @@
-import { DefineOptions, Sequences } from '@thaumaturgy/core';
 import * as t from 'io-ts';
 
-export type EntityName = string;
-
 export type EntityC = t.Any;
-
-export type Define = <
-  C extends EntityC,
-  TSequences extends Sequences,
-  TContext
->(
-  Entity: C,
-  options: DefineOptions<t.TypeOf<C>, TSequences, TContext>
-) => void;
-
-export type Manifest = <C extends EntityC>(
-  Entity: C,
-  overrides?: Partial<t.TypeOf<C>>
-) => t.TypeOf<C>;
-
-export type Persist = <C extends EntityC, TContext = unknown>(
-  Entity: C,
-  overrides?: Partial<t.TypeOf<C>>,
-  context?: TContext
-) => Promise<t.TypeOf<C>>;

--- a/packages/io-ts/src/types.ts
+++ b/packages/io-ts/src/types.ts
@@ -5,9 +5,13 @@ export type EntityName = string;
 
 export type EntityC = t.Any;
 
-export type Define = <C extends EntityC, TSequences extends Sequences>(
+export type Define = <
+  C extends EntityC,
+  TSequences extends Sequences,
+  TContext
+>(
   Entity: C,
-  options: DefineOptions<t.TypeOf<C>, TSequences>
+  options: DefineOptions<t.TypeOf<C>, TSequences, TContext>
 ) => void;
 
 export type Manifest = <C extends EntityC>(

--- a/packages/io-ts/src/types.ts
+++ b/packages/io-ts/src/types.ts
@@ -15,7 +15,8 @@ export type Manifest = <C extends EntityC>(
   overrides?: Partial<t.TypeOf<C>>
 ) => t.TypeOf<C>;
 
-export type Persist = <C extends EntityC>(
+export type Persist = <C extends EntityC, TContext = unknown>(
   Entity: C,
-  overrides?: Partial<t.TypeOf<C>>
+  overrides?: Partial<t.TypeOf<C>>,
+  context?: TContext
 ) => Promise<t.TypeOf<C>>;

--- a/packages/zod/src/__tests__/database.ts
+++ b/packages/zod/src/__tests__/database.ts
@@ -1,0 +1,107 @@
+import SqliteDatabase from 'better-sqlite3';
+import { Kysely, SqliteDialect, sql } from 'kysely';
+
+interface Car {
+  make: string;
+  model: string;
+}
+
+interface Kingdom {
+  name: string;
+}
+
+interface Phylum {
+  kingdom: string;
+  name: string;
+}
+
+interface Class {
+  phylum: string;
+  name: string;
+}
+
+interface Author {
+  id: string;
+  name: string;
+}
+
+interface Post {
+  id: string;
+  author_id: string;
+  title: string;
+}
+
+interface Comment {
+  id: string;
+  post_id: string;
+  username: string;
+}
+
+export interface Database {
+  car: Car;
+  kingdom: Kingdom;
+  phylum: Phylum;
+  class: Class;
+  author: Author;
+  post: Post;
+  comment: Comment;
+}
+
+export const setupDatabase = async () => {
+  const db = new Kysely<Database>({
+    dialect: new SqliteDialect({
+      database: async () => new SqliteDatabase(':memory:'),
+    }),
+  });
+
+  await sql`pragma foreign_keys = on`.execute(db);
+
+  await db.schema
+    .createTable('car')
+    .addColumn('make', 'text', col => col.notNull())
+    .addColumn('model', 'text', col => col.notNull())
+    .execute();
+
+  await db.schema
+    .createTable('kingdom')
+    .addColumn('name', 'text', col => col.primaryKey())
+    .execute();
+
+  await db.schema
+    .createTable('phylum')
+    .addColumn('kingdom', 'text', col => col.notNull())
+    .addColumn('name', 'text', col => col.primaryKey())
+    .addForeignKeyConstraint('phylum_kingdom', ['kingdom'], 'kingdom', ['name'])
+    .execute();
+
+  await db.schema
+    .createTable('class')
+    .addColumn('phylum', 'text', col => col.notNull())
+    .addColumn('name', 'text', col => col.primaryKey())
+    .addForeignKeyConstraint('class_phylum', ['phylum'], 'phylum', ['name'])
+    .execute();
+
+  await db.schema
+    .createTable('author')
+    .addColumn('id', 'text', col => col.primaryKey())
+    .addColumn('name', 'text', col => col.notNull())
+    .execute();
+
+  await db.schema
+    .createTable('post')
+    .addColumn('id', 'text', col => col.primaryKey())
+    .addColumn('author_id', 'text', col => col.notNull())
+    .addColumn('title', 'text', col => col.notNull())
+    .addForeignKeyConstraint('post_author_id', ['author_id'], 'author', ['id'])
+    .execute();
+
+  await db.schema
+    .createTable('comment')
+    .addColumn('id', 'text', col => col.primaryKey())
+    .addColumn('post_id', 'text', col => col.notNull())
+    .addColumn('username', 'text', col => col.notNull())
+    .addForeignKeyConstraint('comment_post_id', ['post_id'], 'post', ['id'])
+    .execute();
+
+  return { db };
+};

--- a/packages/zod/src/__tests__/fixtures.ts
+++ b/packages/zod/src/__tests__/fixtures.ts
@@ -1,0 +1,167 @@
+import { Sequence } from '@thaumaturgy/core';
+import { Transaction } from 'kysely';
+import { z } from 'zod';
+import { Realm } from '../realm';
+import { Ref } from '../ref';
+import { Database } from './database';
+
+export const Car = z
+  .object({
+    make: z.string(),
+    model: z.string(),
+  })
+  .describe('Car');
+
+export const Kingdom = z.object({ name: z.string() }).describe('Kingdom');
+
+export const Phylum = z
+  .object({ kingdom: z.string(), name: z.string() })
+  .describe('Phylum');
+
+export const Class = z
+  .object({ phylum: z.string(), name: z.string() })
+  .describe('Class');
+
+export const Author = z
+  .object({ id: z.string(), name: z.string() })
+  .describe('Author');
+
+export const Post = z
+  .object({
+    id: z.string(),
+    authorId: z.string(),
+    title: z.string(),
+  })
+  .describe('Post');
+
+export const Comment = z
+  .object({
+    id: z.string(),
+    postId: z.string(),
+    username: z.string(),
+  })
+  .describe('Comment');
+
+export interface Context {
+  tx: Transaction<Database>;
+}
+
+export const define = (realm: Realm<Context>) => {
+  realm.define(Car, {
+    manifest: () => ({
+      make: 'Honda',
+      model: 'Civic',
+    }),
+    persist: async (car, { tx }) => {
+      await tx
+        .insertInto('car')
+        .values({ make: car.make, model: car.model })
+        .execute();
+
+      return car;
+    },
+  });
+
+  realm.define(Kingdom, {
+    manifest: () => ({ name: 'Animalia' }),
+    persist: async (kingdom, { tx }) => {
+      await tx.insertInto('kingdom').values({ name: kingdom.name }).execute();
+
+      return kingdom;
+    },
+  });
+
+  realm.define(Phylum, {
+    manifest: () => ({
+      kingdom: Ref.to(Kingdom).through(kingdom => kingdom.name),
+      name: 'Chordata',
+    }),
+    persist: async (phylum, { tx }) => {
+      await tx
+        .insertInto('phylum')
+        .values({ kingdom: phylum.kingdom, name: phylum.name })
+        .execute();
+
+      return phylum;
+    },
+  });
+
+  realm.define(Class, {
+    manifest: () => ({
+      phylum: Ref.to(Phylum).through(phylum => phylum.name),
+      name: 'Mammalia',
+    }),
+    persist: async (class_, { tx }) => {
+      await tx
+        .insertInto('class')
+        .values({ phylum: class_.phylum, name: class_.name })
+        .execute();
+
+      return class_;
+    },
+  });
+
+  realm.define(Author, {
+    sequences: {
+      names: new Sequence(n => `Author ${n}` as const),
+    },
+    manifest: ({ uuid, sequences }) => ({
+      id: uuid(),
+      name: sequences.names.next(),
+    }),
+    persist: async (author, { tx }) => {
+      await tx
+        .insertInto('author')
+        .values({ id: author.id, name: author.name })
+        .execute();
+
+      return author;
+    },
+  });
+
+  realm.define(Post, {
+    sequences: {
+      titles: new Sequence(n => `Post ${n}` as const),
+    },
+    manifest: ({ uuid, sequences }) => ({
+      id: uuid(),
+      authorId: Ref.to(Author).through(author => author.id),
+      title: sequences.titles.next(),
+    }),
+    persist: async (post, { tx }) => {
+      await tx
+        .insertInto('post')
+        .values({
+          id: post.id,
+          author_id: post.authorId,
+          title: post.title,
+        })
+        .execute();
+
+      return post;
+    },
+  });
+
+  realm.define(Comment, {
+    sequences: {
+      usernames: new Sequence(n => `user${n}` as const),
+    },
+    manifest: ({ uuid, sequences }) => ({
+      id: uuid(),
+      postId: Ref.to(Post).through(post => post.id),
+      username: sequences.usernames.next(),
+    }),
+    persist: async (comment, { tx }) => {
+      await tx
+        .insertInto('comment')
+        .values({
+          id: comment.id,
+          post_id: comment.postId,
+          username: comment.username,
+        })
+        .execute();
+
+      return comment;
+    },
+  });
+};

--- a/packages/zod/src/__tests__/realm.persist.test.ts
+++ b/packages/zod/src/__tests__/realm.persist.test.ts
@@ -1,122 +1,39 @@
-import { Sequence } from '@thaumaturgy/core';
-import SqliteDatabase from 'better-sqlite3';
-import { Kysely, SqliteDialect, sql } from 'kysely';
 import { describe, expect, it } from 'vitest';
-import { z } from 'zod';
 import { Realm } from '../realm';
-import { Ref } from '../ref';
-
-interface Car {
-  make: string;
-  model: string;
-}
-
-interface Kingdom {
-  name: string;
-}
-
-interface Phylum {
-  kingdom: string;
-  name: string;
-}
-
-interface Class {
-  phylum: string;
-  name: string;
-}
-
-interface Author {
-  id: string;
-  name: string;
-}
-
-interface Post {
-  id: string;
-  author_id: string;
-  title: string;
-}
-
-interface Comment {
-  id: string;
-  post_id: string;
-  username: string;
-}
-
-interface Database {
-  car: Car;
-  kingdom: Kingdom;
-  phylum: Phylum;
-  class: Class;
-  author: Author;
-  post: Post;
-  comment: Comment;
-}
+import { setupDatabase } from './database';
+import { Car, Class, Comment, Context, define } from './fixtures';
 
 describe('Realm', () => {
+  const performSetup = async () => {
+    const { db } = await setupDatabase();
+
+    const realm = new Realm<Context>();
+
+    define(realm);
+
+    return { db, realm };
+  };
+
   describe('persist', () => {
-    const setupDatabase = async () => {
-      const db = new Kysely<Database>({
-        dialect: new SqliteDialect({
-          database: async () => new SqliteDatabase(':memory:'),
-        }),
-      });
-
-      return { db };
-    };
-
-    const Car = z
-      .object({
-        make: z.string(),
-        model: z.string(),
-      })
-      .describe('Car');
-
-    const performSetup = async () => {
-      const { db } = await setupDatabase();
-
-      await db.schema
-        .createTable('car')
-        .addColumn('make', 'text', col => col.notNull())
-        .addColumn('model', 'text', col => col.notNull())
-        .execute();
-
-      const realm = new Realm();
-
-      realm.define(Car, {
-        manifest: () => ({
-          make: 'Honda',
-          model: 'Civic',
-        }),
-        persist: async car => {
-          await db
-            .insertInto('car')
-            .values({ make: car.make, model: car.model })
-            .execute();
-
-          return car;
-        },
-      });
-
-      return { db, realm };
-    };
-
     describe('with no overrides', () => {
       it('persists an instance of the provided type', async () => {
         const { db, realm } = await performSetup();
 
-        const persisted = await realm.persist(Car);
+        await db.transaction().execute(async tx => {
+          const persisted = await realm.persist(Car, { tx });
 
-        expect(persisted).toEqual({
-          make: 'Honda',
-          model: 'Civic',
+          expect(persisted).toEqual({
+            make: 'Honda',
+            model: 'Civic',
+          });
+
+          const carFromDatabase = await tx
+            .selectFrom('car')
+            .select(['make', 'model'])
+            .executeTakeFirst();
+
+          expect(carFromDatabase).toEqual(persisted);
         });
-
-        const carFromDatabase = await db
-          .selectFrom('car')
-          .select(['make', 'model'])
-          .executeTakeFirst();
-
-        expect(carFromDatabase).toEqual(persisted);
       });
     });
 
@@ -124,306 +41,111 @@ describe('Realm', () => {
       it('persists an instance of the provided type with the overrides applied', async () => {
         const { db, realm } = await performSetup();
 
-        const persisted = await realm.persist(Car, {
-          model: 'CRV',
+        await db.transaction().execute(async tx => {
+          const persisted = await realm.persist(
+            Car,
+            { tx },
+            {
+              model: 'CRV',
+            }
+          );
+
+          expect(persisted).toEqual({
+            make: 'Honda',
+            model: 'CRV',
+          });
+
+          const carFromDatabase = await tx
+            .selectFrom('car')
+            .select(['make', 'model'])
+            .executeTakeFirst();
+
+          expect(carFromDatabase).toEqual(persisted);
         });
-
-        expect(persisted).toEqual({
-          make: 'Honda',
-          model: 'CRV',
-        });
-
-        const carFromDatabase = await db
-          .selectFrom('car')
-          .select(['make', 'model'])
-          .executeTakeFirst();
-
-        expect(carFromDatabase).toEqual(persisted);
       });
     });
 
     describe('for an entity hierarchy', () => {
-      const Kingdom = z.object({ name: z.string() }).describe('Kingdom');
-
-      const Phylum = z
-        .object({ kingdom: z.string(), name: z.string() })
-        .describe('Phylum');
-
-      const Class = z
-        .object({ phylum: z.string(), name: z.string() })
-        .describe('Class');
-
-      const performSetup = async () => {
-        const { db } = await setupDatabase();
-
-        await sql`pragma foreign_keys = on`.execute(db);
-
-        await db.schema
-          .createTable('kingdom')
-          .addColumn('name', 'text', col => col.primaryKey())
-          .execute();
-
-        await db.schema
-          .createTable('phylum')
-          .addColumn('kingdom', 'text', col => col.notNull())
-          .addColumn('name', 'text', col => col.primaryKey())
-          .addForeignKeyConstraint('phylum_kingdom', ['kingdom'], 'kingdom', [
-            'name',
-          ])
-          .execute();
-
-        await db.schema
-          .createTable('class')
-          .addColumn('phylum', 'text', col => col.notNull())
-          .addColumn('name', 'text', col => col.primaryKey())
-          .addForeignKeyConstraint('class_phylum', ['phylum'], 'phylum', [
-            'name',
-          ])
-          .execute();
-
-        const realm = new Realm();
-
-        realm.define(Kingdom, {
-          manifest: () => ({ name: 'Animalia' }),
-          persist: async kingdom => {
-            await db
-              .insertInto('kingdom')
-              .values({ name: kingdom.name })
-              .execute();
-
-            return kingdom;
-          },
-        });
-
-        realm.define(Phylum, {
-          manifest: () => ({
-            kingdom: Ref.to(Kingdom).through(kingdom => kingdom.name),
-            name: 'Chordata',
-          }),
-          persist: async phylum => {
-            await db
-              .insertInto('phylum')
-              .values({ kingdom: phylum.kingdom, name: phylum.name })
-              .execute();
-
-            return phylum;
-          },
-        });
-
-        realm.define(Class, {
-          manifest: () => ({
-            phylum: Ref.to(Phylum).through(phylum => phylum.name),
-            name: 'Mammalia',
-          }),
-          persist: async class_ => {
-            await db
-              .insertInto('class')
-              .values({ phylum: class_.phylum, name: class_.name })
-              .execute();
-
-            return class_;
-          },
-        });
-
-        return { db, realm };
-      };
-
       it('persists an instance of each entity in the hierarchy', async () => {
         const { db, realm } = await performSetup();
 
-        const persisted = await realm.persist(Class);
+        await db.transaction().execute(async tx => {
+          const persisted = await realm.persist(Class, { tx });
 
-        expect(persisted).toEqual({
-          phylum: 'Chordata',
-          name: 'Mammalia',
+          expect(persisted).toEqual({
+            phylum: 'Chordata',
+            name: 'Mammalia',
+          });
+
+          const classFromDatabase = await tx
+            .selectFrom('class')
+            .select(['phylum', 'name'])
+            .executeTakeFirst();
+
+          expect(classFromDatabase).toEqual(persisted);
+
+          const phylumFromDatabase = await tx
+            .selectFrom('phylum')
+            .select(['kingdom', 'name'])
+            .executeTakeFirst();
+
+          expect(phylumFromDatabase).toEqual({
+            kingdom: 'Animalia',
+            name: 'Chordata',
+          });
+
+          const kingdomFromDatabase = await tx
+            .selectFrom('kingdom')
+            .select('name')
+            .executeTakeFirst();
+
+          expect(kingdomFromDatabase).toEqual({ name: 'Animalia' });
         });
-
-        const classFromDatabase = await db
-          .selectFrom('class')
-          .select(['phylum', 'name'])
-          .executeTakeFirst();
-
-        expect(classFromDatabase).toEqual(persisted);
-
-        const phylumFromDatabase = await db
-          .selectFrom('phylum')
-          .select(['kingdom', 'name'])
-          .executeTakeFirst();
-
-        expect(phylumFromDatabase).toEqual({
-          kingdom: 'Animalia',
-          name: 'Chordata',
-        });
-
-        const kingdomFromDatabase = await db
-          .selectFrom('kingdom')
-          .select('name')
-          .executeTakeFirst();
-
-        expect(kingdomFromDatabase).toEqual({ name: 'Animalia' });
       });
     });
 
     describe('for an entity hierarchy with randomly-generated IDs', () => {
-      const Author = z
-        .object({ id: z.string(), name: z.string() })
-        .describe('Author');
-
-      const Post = z
-        .object({
-          id: z.string(),
-          authorId: z.string(),
-          title: z.string(),
-        })
-        .describe('Post');
-
-      const Comment = z
-        .object({
-          id: z.string(),
-          postId: z.string(),
-          username: z.string(),
-        })
-        .describe('Comment');
-
-      const performSetup = async () => {
-        const { db } = await setupDatabase();
-
-        await sql`pragma foreign_keys = on`.execute(db);
-
-        await db.schema
-          .createTable('author')
-          .addColumn('id', 'text', col => col.primaryKey())
-          .addColumn('name', 'text', col => col.notNull())
-          .execute();
-
-        await db.schema
-          .createTable('post')
-          .addColumn('id', 'text', col => col.primaryKey())
-          .addColumn('author_id', 'text', col => col.notNull())
-          .addColumn('title', 'text', col => col.notNull())
-          .addForeignKeyConstraint('post_author_id', ['author_id'], 'author', [
-            'id',
-          ])
-          .execute();
-
-        await db.schema
-          .createTable('comment')
-          .addColumn('id', 'text', col => col.primaryKey())
-          .addColumn('post_id', 'text', col => col.notNull())
-          .addColumn('username', 'text', col => col.notNull())
-          .addForeignKeyConstraint('comment_post_id', ['post_id'], 'post', [
-            'id',
-          ])
-          .execute();
-
-        const realm = new Realm();
-
-        realm.define(Author, {
-          sequences: {
-            names: new Sequence(n => `Author ${n}` as const),
-          },
-          manifest: ({ uuid, sequences }) => ({
-            id: uuid(),
-            name: sequences.names.next(),
-          }),
-          persist: async author => {
-            await db
-              .insertInto('author')
-              .values({ id: author.id, name: author.name })
-              .execute();
-
-            return author;
-          },
-        });
-
-        realm.define(Post, {
-          sequences: {
-            titles: new Sequence(n => `Post ${n}` as const),
-          },
-          manifest: ({ uuid, sequences }) => ({
-            id: uuid(),
-            authorId: Ref.to(Author).through(author => author.id),
-            title: sequences.titles.next(),
-          }),
-          persist: async post => {
-            await db
-              .insertInto('post')
-              .values({
-                id: post.id,
-                author_id: post.authorId,
-                title: post.title,
-              })
-              .execute();
-
-            return post;
-          },
-        });
-
-        realm.define(Comment, {
-          sequences: {
-            usernames: new Sequence(n => `user${n}` as const),
-          },
-          manifest: ({ uuid, sequences }) => ({
-            id: uuid(),
-            postId: Ref.to(Post).through(post => post.id),
-            username: sequences.usernames.next(),
-          }),
-          persist: async comment => {
-            await db
-              .insertInto('comment')
-              .values({
-                id: comment.id,
-                post_id: comment.postId,
-                username: comment.username,
-              })
-              .execute();
-
-            return comment;
-          },
-        });
-
-        return { db, realm };
-      };
-
       it('persists an instance of each entity in the hierarchy', async () => {
         const { db, realm } = await performSetup();
 
-        const comment = await realm.persist(Comment);
+        await db.transaction().execute(async tx => {
+          const comment = await realm.persist(Comment, { tx });
 
-        const commentsInDatabase = await db
-          .selectFrom('comment')
-          .selectAll()
-          .execute();
+          const commentsInDatabase = await tx
+            .selectFrom('comment')
+            .selectAll()
+            .execute();
 
-        expect(commentsInDatabase).toEqual([
-          {
-            id: comment.id,
-            post_id: comment.postId,
-            username: comment.username,
-          },
-        ]);
+          expect(commentsInDatabase).toEqual([
+            {
+              id: comment.id,
+              post_id: comment.postId,
+              username: comment.username,
+            },
+          ]);
 
-        const postsInDatabase = await db
-          .selectFrom('post')
-          .selectAll()
-          .execute();
+          const postsInDatabase = await tx
+            .selectFrom('post')
+            .selectAll()
+            .execute();
 
-        expect(postsInDatabase).toEqual([
-          {
-            id: comment.postId,
-            author_id: expect.any(String),
-            title: expect.any(String),
-          },
-        ]);
+          expect(postsInDatabase).toEqual([
+            {
+              id: comment.postId,
+              author_id: expect.any(String),
+              title: expect.any(String),
+            },
+          ]);
 
-        const authorsInDatabase = await db
-          .selectFrom('author')
-          .selectAll()
-          .execute();
+          const authorsInDatabase = await tx
+            .selectFrom('author')
+            .selectAll()
+            .execute();
 
-        expect(authorsInDatabase).toEqual([
-          { id: postsInDatabase[0]?.author_id, name: expect.any(String) },
-        ]);
+          expect(authorsInDatabase).toEqual([
+            { id: postsInDatabase[0]?.author_id, name: expect.any(String) },
+          ]);
+        });
       });
     });
   });

--- a/packages/zod/src/realm.ts
+++ b/packages/zod/src/realm.ts
@@ -5,7 +5,7 @@ import {
 } from '@thaumaturgy/core';
 import { z } from 'zod';
 import { extractEntityName } from './entity-name';
-import { EntityC, Manifest } from './types';
+import { EntityC } from './types';
 
 /**
  * A realm is an isolated environment that entities may be registered with.
@@ -38,7 +38,10 @@ export class Realm<TContext> {
    * @param Entity The entity to manifest.
    * @param overrides The overrides to pass to the manifester.
    */
-  readonly manifest: Manifest = (Entity, overrides = {}) => {
+  readonly manifest = <C extends EntityC>(
+    Entity: C,
+    overrides: Partial<z.TypeOf<C>> = {}
+  ): z.TypeOf<C> => {
     return this.realm.manifest(
       { C: Entity, name: extractEntityName(Entity) },
       overrides

--- a/packages/zod/src/realm.ts
+++ b/packages/zod/src/realm.ts
@@ -43,10 +43,11 @@ export class Realm {
    * @param Entity The entity to persist.
    * @param overrides The overrides to pass to the persister.
    */
-  readonly persist: Persist = async (Entity, overrides = {}) => {
+  readonly persist: Persist = async (Entity, overrides = {}, context) => {
     return this.realm.persist(
       { C: Entity, name: extractEntityName(Entity) },
-      overrides
+      overrides,
+      context
     );
   };
 

--- a/packages/zod/src/types.ts
+++ b/packages/zod/src/types.ts
@@ -5,18 +5,16 @@ export type EntityName = string;
 
 export type EntityC = z.ZodTypeAny;
 
-export type Define = <C extends EntityC, TSequences extends Sequences>(
+export type Define = <
+  C extends EntityC,
+  TSequences extends Sequences,
+  TContext
+>(
   Entity: C,
-  options: DefineOptions<z.TypeOf<C>, TSequences>
+  options: DefineOptions<z.TypeOf<C>, TSequences, TContext>
 ) => void;
 
 export type Manifest = <C extends EntityC>(
   Entity: C,
   overrides?: Partial<z.TypeOf<C>>
 ) => z.TypeOf<C>;
-
-export type Persist = <C extends EntityC, TContext = unknown>(
-  Entity: C,
-  overrides?: Partial<z.TypeOf<C>>,
-  context?: TContext
-) => Promise<z.TypeOf<C>>;

--- a/packages/zod/src/types.ts
+++ b/packages/zod/src/types.ts
@@ -1,20 +1,3 @@
-import { DefineOptions, Sequences } from '@thaumaturgy/core';
 import { z } from 'zod';
 
-export type EntityName = string;
-
 export type EntityC = z.ZodTypeAny;
-
-export type Define = <
-  C extends EntityC,
-  TSequences extends Sequences,
-  TContext
->(
-  Entity: C,
-  options: DefineOptions<z.TypeOf<C>, TSequences, TContext>
-) => void;
-
-export type Manifest = <C extends EntityC>(
-  Entity: C,
-  overrides?: Partial<z.TypeOf<C>>
-) => z.TypeOf<C>;

--- a/packages/zod/src/types.ts
+++ b/packages/zod/src/types.ts
@@ -15,7 +15,8 @@ export type Manifest = <C extends EntityC>(
   overrides?: Partial<z.TypeOf<C>>
 ) => z.TypeOf<C>;
 
-export type Persist = <C extends EntityC>(
+export type Persist = <C extends EntityC, TContext = unknown>(
   Entity: C,
-  overrides?: Partial<z.TypeOf<C>>
+  overrides?: Partial<z.TypeOf<C>>,
+  context?: TContext
 ) => Promise<z.TypeOf<C>>;


### PR DESCRIPTION
This PR adds support for a context parameter for persisters.

This allows for threading state through `persist` to the `persister` function. For instance, passing in a transaction to use in the persister.

This probably breaks the global API, so I expect to deprecate that in the near future.